### PR TITLE
updated connection info and autoscale APIs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$|.cra/.cveignore",
     "lines": null
   },
-  "generated_at": "2024-11-27T10:57:06Z",
+  "generated_at": "2024-12-06T11:09:55Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -96,13 +96,6 @@
         "is_verified": false,
         "line_number": 60,
         "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2cc781080ce377922ae4348239d0b7eebb7c324",
-        "is_verified": false,
-        "line_number": 305,
-        "type": "Base64 High Entropy String",
         "verified_result": null
       },
       {

--- a/db2saasv1/db2saas_v1.go
+++ b/db2saasv1/db2saas_v1.go
@@ -733,8 +733,8 @@ func (db2saas *Db2saasV1) PutDb2SaasAutoscaleWithContext(ctx context.Context, pu
 	}
 	builder.AddHeader("Accept", "application/json")
 	builder.AddHeader("Content-Type", "application/json")
-	if putDb2SaasAutoscaleOptions.XDeploymentID != nil {
-		builder.AddHeader("x-deployment-id", fmt.Sprint(*putDb2SaasAutoscaleOptions.XDeploymentID))
+	if putDb2SaasAutoscaleOptions.XDbProfile != nil {
+		builder.AddHeader("x-db-profile", fmt.Sprint(*putDb2SaasAutoscaleOptions.XDbProfile))
 	}
 
 	body := make(map[string]interface{})
@@ -822,8 +822,8 @@ func (db2saas *Db2saasV1) GetDb2SaasAutoscaleWithContext(ctx context.Context, ge
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
-	if getDb2SaasAutoscaleOptions.XDeploymentID != nil {
-		builder.AddHeader("x-deployment-id", fmt.Sprint(*getDb2SaasAutoscaleOptions.XDeploymentID))
+	if getDb2SaasAutoscaleOptions.XDbProfile != nil {
+		builder.AddHeader("x-db-profile", fmt.Sprint(*getDb2SaasAutoscaleOptions.XDbProfile))
 	}
 
 	request, err := builder.Build()
@@ -934,22 +934,22 @@ func (options *DeleteDb2SaasUserOptions) SetHeaders(param map[string]string) *De
 // GetDb2SaasAutoscaleOptions : The GetDb2SaasAutoscale options.
 type GetDb2SaasAutoscaleOptions struct {
 	// CRN deployment id.
-	XDeploymentID *string `json:"x-deployment-id" validate:"required"`
+	XDbProfile *string `json:"x-db-profile" validate:"required"`
 
 	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
 // NewGetDb2SaasAutoscaleOptions : Instantiate GetDb2SaasAutoscaleOptions
-func (*Db2saasV1) NewGetDb2SaasAutoscaleOptions(xDeploymentID string) *GetDb2SaasAutoscaleOptions {
+func (*Db2saasV1) NewGetDb2SaasAutoscaleOptions(xDbProfile string) *GetDb2SaasAutoscaleOptions {
 	return &GetDb2SaasAutoscaleOptions{
-		XDeploymentID: core.StringPtr(xDeploymentID),
+		XDbProfile: core.StringPtr(xDbProfile),
 	}
 }
 
-// SetXDeploymentID : Allow user to set XDeploymentID
-func (_options *GetDb2SaasAutoscaleOptions) SetXDeploymentID(xDeploymentID string) *GetDb2SaasAutoscaleOptions {
-	_options.XDeploymentID = core.StringPtr(xDeploymentID)
+// SetXDbProfile : Allow user to set XDbProfile
+func (_options *GetDb2SaasAutoscaleOptions) SetXDbProfile(xDbProfile string) *GetDb2SaasAutoscaleOptions {
+	_options.XDbProfile = core.StringPtr(xDbProfile)
 	return _options
 }
 
@@ -1292,7 +1292,7 @@ func (options *PostDb2SaasWhitelistOptions) SetHeaders(param map[string]string) 
 // PutDb2SaasAutoscaleOptions : The PutDb2SaasAutoscale options.
 type PutDb2SaasAutoscaleOptions struct {
 	// CRN deployment id.
-	XDeploymentID *string `json:"x-deployment-id" validate:"required"`
+	XDbProfile *string `json:"x-db-profile" validate:"required"`
 
 	// Indicates if automatic scaling is enabled or not.
 	AutoScalingEnabled *string `json:"auto_scaling_enabled,omitempty"`
@@ -1328,15 +1328,15 @@ const (
 )
 
 // NewPutDb2SaasAutoscaleOptions : Instantiate PutDb2SaasAutoscaleOptions
-func (*Db2saasV1) NewPutDb2SaasAutoscaleOptions(xDeploymentID string) *PutDb2SaasAutoscaleOptions {
+func (*Db2saasV1) NewPutDb2SaasAutoscaleOptions(xDbProfile string) *PutDb2SaasAutoscaleOptions {
 	return &PutDb2SaasAutoscaleOptions{
-		XDeploymentID: core.StringPtr(xDeploymentID),
+		XDbProfile: core.StringPtr(xDbProfile),
 	}
 }
 
-// SetXDeploymentID : Allow user to set XDeploymentID
-func (_options *PutDb2SaasAutoscaleOptions) SetXDeploymentID(xDeploymentID string) *PutDb2SaasAutoscaleOptions {
-	_options.XDeploymentID = core.StringPtr(xDeploymentID)
+// SetXDbProfile : Allow user to set XDbProfile
+func (_options *PutDb2SaasAutoscaleOptions) SetXDbProfile(xDbProfile string) *PutDb2SaasAutoscaleOptions {
+	_options.XDbProfile = core.StringPtr(xDbProfile)
 	return _options
 }
 
@@ -1488,15 +1488,19 @@ type SuccessConnectionInfoPrivate struct {
 
 	DatabaseName *string `json:"databaseName,omitempty"`
 
-	HostRos *string `json:"host_ros,omitempty"`
-
-	CertificateBase64 *string `json:"certificateBase64,omitempty"`
-
 	SslPort *string `json:"sslPort,omitempty"`
 
 	Ssl *bool `json:"ssl,omitempty"`
 
 	DatabaseVersion *string `json:"databaseVersion,omitempty"`
+
+	PrivateServiceName *string `json:"private_serviceName,omitempty"`
+
+	CloudServiceOffering *string `json:"cloud_service_offering,omitempty"`
+
+	VpeServiceCrn *string `json:"vpe_service_crn,omitempty"`
+
+	DbVpcEndpointService *string `json:"db_vpc_endpoint_service,omitempty"`
 }
 
 // UnmarshalSuccessConnectionInfoPrivate unmarshals an instance of SuccessConnectionInfoPrivate from the specified map of raw messages.
@@ -1510,16 +1514,6 @@ func UnmarshalSuccessConnectionInfoPrivate(m map[string]json.RawMessage, result 
 	err = core.UnmarshalPrimitive(m, "databaseName", &obj.DatabaseName)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "databaseName-error", common.GetComponentInfo())
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "host_ros", &obj.HostRos)
-	if err != nil {
-		err = core.SDKErrorf(err, "", "host_ros-error", common.GetComponentInfo())
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "certificateBase64", &obj.CertificateBase64)
-	if err != nil {
-		err = core.SDKErrorf(err, "", "certificateBase64-error", common.GetComponentInfo())
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "sslPort", &obj.SslPort)
@@ -1537,6 +1531,26 @@ func UnmarshalSuccessConnectionInfoPrivate(m map[string]json.RawMessage, result 
 		err = core.SDKErrorf(err, "", "databaseVersion-error", common.GetComponentInfo())
 		return
 	}
+	err = core.UnmarshalPrimitive(m, "private_serviceName", &obj.PrivateServiceName)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "private_serviceName-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "cloud_service_offering", &obj.CloudServiceOffering)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "cloud_service_offering-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "vpe_service_crn", &obj.VpeServiceCrn)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "vpe_service_crn-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "db_vpc_endpoint_service", &obj.DbVpcEndpointService)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "db_vpc_endpoint_service-error", common.GetComponentInfo())
+		return
+	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
 	return
 }
@@ -1546,10 +1560,6 @@ type SuccessConnectionInfoPublic struct {
 	Hostname *string `json:"hostname,omitempty"`
 
 	DatabaseName *string `json:"databaseName,omitempty"`
-
-	HostRos *string `json:"host_ros,omitempty"`
-
-	CertificateBase64 *string `json:"certificateBase64,omitempty"`
 
 	SslPort *string `json:"sslPort,omitempty"`
 
@@ -1569,16 +1579,6 @@ func UnmarshalSuccessConnectionInfoPublic(m map[string]json.RawMessage, result i
 	err = core.UnmarshalPrimitive(m, "databaseName", &obj.DatabaseName)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "databaseName-error", common.GetComponentInfo())
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "host_ros", &obj.HostRos)
-	if err != nil {
-		err = core.SDKErrorf(err, "", "host_ros-error", common.GetComponentInfo())
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "certificateBase64", &obj.CertificateBase64)
-	if err != nil {
-		err = core.SDKErrorf(err, "", "certificateBase64-error", common.GetComponentInfo())
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "sslPort", &obj.SslPort)

--- a/db2saasv1/db2saas_v1_integration_test.go
+++ b/db2saasv1/db2saas_v1_integration_test.go
@@ -214,7 +214,7 @@ var _ = Describe(`Db2saasV1 Integration Tests`, func() {
 		})
 		It(`PutDb2SaasAutoscale(putDb2SaasAutoscaleOptions *PutDb2SaasAutoscaleOptions)`, func() {
 			putDb2SaasAutoscaleOptions := &db2saasv1.PutDb2SaasAutoscaleOptions{
-				XDeploymentID:         core.StringPtr("testString"),
+				XDbProfile:            core.StringPtr("testString"),
 				AutoScalingThreshold:  core.Int64Ptr(int64(90)),
 				AutoScalingPauseLimit: core.Int64Ptr(int64(70)),
 			}
@@ -232,7 +232,7 @@ var _ = Describe(`Db2saasV1 Integration Tests`, func() {
 		})
 		It(`GetDb2SaasAutoscale(getDb2SaasAutoscaleOptions *GetDb2SaasAutoscaleOptions)`, func() {
 			getDb2SaasAutoscaleOptions := &db2saasv1.GetDb2SaasAutoscaleOptions{
-				XDeploymentID: core.StringPtr("testString"),
+				XDbProfile: core.StringPtr("testString"),
 			}
 
 			successAutoScaling, response, err := db2saasService.GetDb2SaasAutoscale(getDb2SaasAutoscaleOptions)

--- a/db2saasv1/db2saas_v1_test.go
+++ b/db2saasv1/db2saas_v1_test.go
@@ -245,7 +245,7 @@ var _ = Describe(`Db2saasV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"public": {"hostname": "84792aeb-2a9c-4dee-bfad-2e529f16945d-useast-private.bt1ibm.dev.db2.ibmappdomain.cloud", "databaseName": "bluedb", "host_ros": "84792aeb-2a9c-4dee-bfad-2e529f16945d-useast-private.bt1ibm.dev.db2.ibmappdomain.cloud:30515", "certificateBase64": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURIVENDQWdXZ0F3SUJBZ0lVTGRpR1U2QzdZajMwcS9VUVB3ek5ka2YyakJjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0hqRWNNQm9HQTFVRUF3d1RTVUpOSUVOc2IzVmtJRVJoZEdGaVlYTmxjekFlRncweU1EQTRNRFl3T1RReQpNVEZhRncwek1EQTRNRFF3T1RReU1URmFNQjR4SERBYUJnTlZCQU1NRTBsQ1RTQkRiRzkxWkNCRVlYUmhZbUZ6ClpYTXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDb1NIdS9TWkd5NHc0bHB0elQKbFVRQTV6Q0krTldhblQ0czAvTXFkQmJwRW9FWjYxLy9VQVFPaHVTUG85M05obG1NQWZUWENpUi9jVkxuQmxBMQpuZnEzcC9pWm1VMnJwSUxnUmdLeTdsNEZSMVVPaGlRa3RnN3d6Q0J1M2k0bTRJQkZ0NVVvRng5djl6eFkrK0tSCnNnYXhmK28yMEoxLzZBSHFwem5GaWJuTDdLcGlZMUs1c25BdHFwTUVsNHMyR3dlZXQ0dEFjZ3hRSlRVR3hvamsKUDMvUmtxSUI1RFBNSXJ0ZFMrWWpBdlM0alBpREVRT0FvZDg5aDBOays3bkpldllJT0lRVTN0OC81YlNYRDFFVwp3bmRqdHlkeC95Qlo5YlZ4bms4eWI1S1NCVUNpaHJsL1AxVmdNdStLb2w2M0ZZMmdSbndwb3FEOVRNWkJkeTRYCk5PRUZBZ01CQUFHalV6QlJNQjBHQTFVZERnUVdCQlNldmNpblMvR0VwdmlmZkQ0ZUtPU0FNSGljUmpBZkJnTlYKSFNNRUdEQVdnQlNldmNpblMvR0VwdmlmZkQ0ZUtPU0FNSGljUmpBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQkFRQk1XRHV2Z0JKVk5JYUp2NkFzL3FybWZKbVJObU80clhVcXhiTXdJdEZ1Ciswb1RIOTZMWU1OSjgyS1hXOFc1K0ZUOXJ2TjdzQzhRQzBYVzFIWkM4dlgvdE96dmluL1lqVW5nUlducUFBQXEKL0U4TnRtMFpuMEs4cnRzanJtaklLKzlwNjRObE1ENWJjcUpDMGZFSkpBQVpBSUozejRNSHhsTDhnc0plS0JyOApvcWhhejJOaXJtSEZ3Z3RDc0htVlI4UCt5TUtrN24xVlhlcmpHYWhORkQ2MzhGRnRoSHNvNmV0NGQ5NEpLTXFPCmt1cWhFOCtMcTZlalRWUTRYdldaUG4wVWlZQkVpTjFsT1JaZ0h5d3JvNjJ5Z2dFekhCaXF5dEI2SEN6TllyYXoKVElQUTNGanhGQXNYU3NhVzZPL2VteERNSDN4ZUZ5WmRZWWw5bGMxSnFVWW4KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=", "sslPort": "30450", "ssl": true, "databaseVersion": "11.5.0"}, "private": {"hostname": "84792aeb-2a9c-4dee-bfad-2e529f16945d-useast.bt1ibm.dev.db2.ibmappdomain.cloud", "databaseName": "bluedb", "host_ros": "84792aeb-2a9c-4dee-bfad-2e529f16945d-useast.bt1ibm.dev.db2.ibmappdomain.cloud:30515", "certificateBase64": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURIVENDQWdXZ0F3SUJBZ0lVTGRpR1U2QzdZajMwcS9VUVB3ek5ka2YyakJjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0hqRWNNQm9HQTFVRUF3d1RTVUpOSUVOc2IzVmtJRVJoZEdGaVlYTmxjekFlRncweU1EQTRNRFl3T1RReQpNVEZhRncwek1EQTRNRFF3T1RReU1URmFNQjR4SERBYUJnTlZCQU1NRTBsQ1RTQkRiRzkxWkNCRVlYUmhZbUZ6ClpYTXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDb1NIdS9TWkd5NHc0bHB0elQKbFVRQTV6Q0krTldhblQ0czAvTXFkQmJwRW9FWjYxLy9VQVFPaHVTUG85M05obG1NQWZUWENpUi9jVkxuQmxBMQpuZnEzcC9pWm1VMnJwSUxnUmdLeTdsNEZSMVVPaGlRa3RnN3d6Q0J1M2k0bTRJQkZ0NVVvRng5djl6eFkrK0tSCnNnYXhmK28yMEoxLzZBSHFwem5GaWJuTDdLcGlZMUs1c25BdHFwTUVsNHMyR3dlZXQ0dEFjZ3hRSlRVR3hvamsKUDMvUmtxSUI1RFBNSXJ0ZFMrWWpBdlM0alBpREVRT0FvZDg5aDBOays3bkpldllJT0lRVTN0OC81YlNYRDFFVwp3bmRqdHlkeC95Qlo5YlZ4bms4eWI1S1NCVUNpaHJsL1AxVmdNdStLb2w2M0ZZMmdSbndwb3FEOVRNWkJkeTRYCk5PRUZBZ01CQUFHalV6QlJNQjBHQTFVZERnUVdCQlNldmNpblMvR0VwdmlmZkQ0ZUtPU0FNSGljUmpBZkJnTlYKSFNNRUdEQVdnQlNldmNpblMvR0VwdmlmZkQ0ZUtPU0FNSGljUmpBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQkFRQk1XRHV2Z0JKVk5JYUp2NkFzL3FybWZKbVJObU80clhVcXhiTXdJdEZ1Ciswb1RIOTZMWU1OSjgyS1hXOFc1K0ZUOXJ2TjdzQzhRQzBYVzFIWkM4dlgvdE96dmluL1lqVW5nUlducUFBQXEKL0U4TnRtMFpuMEs4cnRzanJtaklLKzlwNjRObE1ENWJjcUpDMGZFSkpBQVpBSUozejRNSHhsTDhnc0plS0JyOApvcWhhejJOaXJtSEZ3Z3RDc0htVlI4UCt5TUtrN24xVlhlcmpHYWhORkQ2MzhGRnRoSHNvNmV0NGQ5NEpLTXFPCmt1cWhFOCtMcTZlalRWUTRYdldaUG4wVWlZQkVpTjFsT1JaZ0h5d3JvNjJ5Z2dFekhCaXF5dEI2SEN6TllyYXoKVElQUTNGanhGQXNYU3NhVzZPL2VteERNSDN4ZUZ5WmRZWWw5bGMxSnFVWW4KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=", "sslPort": "30450", "ssl": true, "databaseVersion": "11.5.0"}}`)
+					fmt.Fprintf(res, "%s", `{"public": {"hostname": "84792aeb-2a9c-4dee-bfad-2e529f16945d-useast-private.bt1ibm.dev.db2.ibmappdomain.cloud", "databaseName": "bluedb", "sslPort": "30450", "ssl": true, "databaseVersion": "11.5.0"}, "private": {"hostname": "84792aeb-2a9c-4dee-bfad-2e529f16945d-useast.bt1ibm.dev.db2.ibmappdomain.cloud", "databaseName": "bluedb", "sslPort": "30450", "ssl": true, "databaseVersion": "11.5.0", "private_serviceName": "us-south-private.db2oc.test.saas.ibm.com:32764", "cloud_service_offering": "dashdb-for-transactions", "vpe_service_crn": "crn:v1:staging:public:dashdb-for-transactions:us-south:::endpoint:feea41a1-ff88-4541-8865-0698ccb7c5dc-us-south-private.bt1ibm.dev.db2.ibmappdomain.cloud", "db_vpc_endpoint_service": "feea41a1-ff88-4541-8865-0698ccb7c5dc-ussouth-private.bt1ibm.dev.db2.ibmappdomain.cloud:32679"}}`)
 				}))
 			})
 			It(`Invoke GetDb2SaasConnectionInfo successfully with retries`, func() {
@@ -302,7 +302,7 @@ var _ = Describe(`Db2saasV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"public": {"hostname": "84792aeb-2a9c-4dee-bfad-2e529f16945d-useast-private.bt1ibm.dev.db2.ibmappdomain.cloud", "databaseName": "bluedb", "host_ros": "84792aeb-2a9c-4dee-bfad-2e529f16945d-useast-private.bt1ibm.dev.db2.ibmappdomain.cloud:30515", "certificateBase64": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURIVENDQWdXZ0F3SUJBZ0lVTGRpR1U2QzdZajMwcS9VUVB3ek5ka2YyakJjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0hqRWNNQm9HQTFVRUF3d1RTVUpOSUVOc2IzVmtJRVJoZEdGaVlYTmxjekFlRncweU1EQTRNRFl3T1RReQpNVEZhRncwek1EQTRNRFF3T1RReU1URmFNQjR4SERBYUJnTlZCQU1NRTBsQ1RTQkRiRzkxWkNCRVlYUmhZbUZ6ClpYTXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDb1NIdS9TWkd5NHc0bHB0elQKbFVRQTV6Q0krTldhblQ0czAvTXFkQmJwRW9FWjYxLy9VQVFPaHVTUG85M05obG1NQWZUWENpUi9jVkxuQmxBMQpuZnEzcC9pWm1VMnJwSUxnUmdLeTdsNEZSMVVPaGlRa3RnN3d6Q0J1M2k0bTRJQkZ0NVVvRng5djl6eFkrK0tSCnNnYXhmK28yMEoxLzZBSHFwem5GaWJuTDdLcGlZMUs1c25BdHFwTUVsNHMyR3dlZXQ0dEFjZ3hRSlRVR3hvamsKUDMvUmtxSUI1RFBNSXJ0ZFMrWWpBdlM0alBpREVRT0FvZDg5aDBOays3bkpldllJT0lRVTN0OC81YlNYRDFFVwp3bmRqdHlkeC95Qlo5YlZ4bms4eWI1S1NCVUNpaHJsL1AxVmdNdStLb2w2M0ZZMmdSbndwb3FEOVRNWkJkeTRYCk5PRUZBZ01CQUFHalV6QlJNQjBHQTFVZERnUVdCQlNldmNpblMvR0VwdmlmZkQ0ZUtPU0FNSGljUmpBZkJnTlYKSFNNRUdEQVdnQlNldmNpblMvR0VwdmlmZkQ0ZUtPU0FNSGljUmpBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQkFRQk1XRHV2Z0JKVk5JYUp2NkFzL3FybWZKbVJObU80clhVcXhiTXdJdEZ1Ciswb1RIOTZMWU1OSjgyS1hXOFc1K0ZUOXJ2TjdzQzhRQzBYVzFIWkM4dlgvdE96dmluL1lqVW5nUlducUFBQXEKL0U4TnRtMFpuMEs4cnRzanJtaklLKzlwNjRObE1ENWJjcUpDMGZFSkpBQVpBSUozejRNSHhsTDhnc0plS0JyOApvcWhhejJOaXJtSEZ3Z3RDc0htVlI4UCt5TUtrN24xVlhlcmpHYWhORkQ2MzhGRnRoSHNvNmV0NGQ5NEpLTXFPCmt1cWhFOCtMcTZlalRWUTRYdldaUG4wVWlZQkVpTjFsT1JaZ0h5d3JvNjJ5Z2dFekhCaXF5dEI2SEN6TllyYXoKVElQUTNGanhGQXNYU3NhVzZPL2VteERNSDN4ZUZ5WmRZWWw5bGMxSnFVWW4KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=", "sslPort": "30450", "ssl": true, "databaseVersion": "11.5.0"}, "private": {"hostname": "84792aeb-2a9c-4dee-bfad-2e529f16945d-useast.bt1ibm.dev.db2.ibmappdomain.cloud", "databaseName": "bluedb", "host_ros": "84792aeb-2a9c-4dee-bfad-2e529f16945d-useast.bt1ibm.dev.db2.ibmappdomain.cloud:30515", "certificateBase64": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURIVENDQWdXZ0F3SUJBZ0lVTGRpR1U2QzdZajMwcS9VUVB3ek5ka2YyakJjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0hqRWNNQm9HQTFVRUF3d1RTVUpOSUVOc2IzVmtJRVJoZEdGaVlYTmxjekFlRncweU1EQTRNRFl3T1RReQpNVEZhRncwek1EQTRNRFF3T1RReU1URmFNQjR4SERBYUJnTlZCQU1NRTBsQ1RTQkRiRzkxWkNCRVlYUmhZbUZ6ClpYTXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDb1NIdS9TWkd5NHc0bHB0elQKbFVRQTV6Q0krTldhblQ0czAvTXFkQmJwRW9FWjYxLy9VQVFPaHVTUG85M05obG1NQWZUWENpUi9jVkxuQmxBMQpuZnEzcC9pWm1VMnJwSUxnUmdLeTdsNEZSMVVPaGlRa3RnN3d6Q0J1M2k0bTRJQkZ0NVVvRng5djl6eFkrK0tSCnNnYXhmK28yMEoxLzZBSHFwem5GaWJuTDdLcGlZMUs1c25BdHFwTUVsNHMyR3dlZXQ0dEFjZ3hRSlRVR3hvamsKUDMvUmtxSUI1RFBNSXJ0ZFMrWWpBdlM0alBpREVRT0FvZDg5aDBOays3bkpldllJT0lRVTN0OC81YlNYRDFFVwp3bmRqdHlkeC95Qlo5YlZ4bms4eWI1S1NCVUNpaHJsL1AxVmdNdStLb2w2M0ZZMmdSbndwb3FEOVRNWkJkeTRYCk5PRUZBZ01CQUFHalV6QlJNQjBHQTFVZERnUVdCQlNldmNpblMvR0VwdmlmZkQ0ZUtPU0FNSGljUmpBZkJnTlYKSFNNRUdEQVdnQlNldmNpblMvR0VwdmlmZkQ0ZUtPU0FNSGljUmpBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQkFRQk1XRHV2Z0JKVk5JYUp2NkFzL3FybWZKbVJObU80clhVcXhiTXdJdEZ1Ciswb1RIOTZMWU1OSjgyS1hXOFc1K0ZUOXJ2TjdzQzhRQzBYVzFIWkM4dlgvdE96dmluL1lqVW5nUlducUFBQXEKL0U4TnRtMFpuMEs4cnRzanJtaklLKzlwNjRObE1ENWJjcUpDMGZFSkpBQVpBSUozejRNSHhsTDhnc0plS0JyOApvcWhhejJOaXJtSEZ3Z3RDc0htVlI4UCt5TUtrN24xVlhlcmpHYWhORkQ2MzhGRnRoSHNvNmV0NGQ5NEpLTXFPCmt1cWhFOCtMcTZlalRWUTRYdldaUG4wVWlZQkVpTjFsT1JaZ0h5d3JvNjJ5Z2dFekhCaXF5dEI2SEN6TllyYXoKVElQUTNGanhGQXNYU3NhVzZPL2VteERNSDN4ZUZ5WmRZWWw5bGMxSnFVWW4KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=", "sslPort": "30450", "ssl": true, "databaseVersion": "11.5.0"}}`)
+					fmt.Fprintf(res, "%s", `{"public": {"hostname": "84792aeb-2a9c-4dee-bfad-2e529f16945d-useast-private.bt1ibm.dev.db2.ibmappdomain.cloud", "databaseName": "bluedb", "sslPort": "30450", "ssl": true, "databaseVersion": "11.5.0"}, "private": {"hostname": "84792aeb-2a9c-4dee-bfad-2e529f16945d-useast.bt1ibm.dev.db2.ibmappdomain.cloud", "databaseName": "bluedb", "sslPort": "30450", "ssl": true, "databaseVersion": "11.5.0", "private_serviceName": "us-south-private.db2oc.test.saas.ibm.com:32764", "cloud_service_offering": "dashdb-for-transactions", "vpe_service_crn": "crn:v1:staging:public:dashdb-for-transactions:us-south:::endpoint:feea41a1-ff88-4541-8865-0698ccb7c5dc-us-south-private.bt1ibm.dev.db2.ibmappdomain.cloud", "db_vpc_endpoint_service": "feea41a1-ff88-4541-8865-0698ccb7c5dc-ussouth-private.bt1ibm.dev.db2.ibmappdomain.cloud:32679"}}`)
 				}))
 			})
 			It(`Invoke GetDb2SaasConnectionInfo successfully`, func() {
@@ -1840,8 +1840,8 @@ var _ = Describe(`Db2saasV1`, func() {
 					// Verify the contents of the request
 					Expect(req.URL.EscapedPath()).To(Equal(putDb2SaasAutoscalePath))
 					Expect(req.Method).To(Equal("PUT"))
-					Expect(req.Header["X-Deployment-Id"]).ToNot(BeNil())
-					Expect(req.Header["X-Deployment-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					Expect(req.Header["X-Db-Profile"]).ToNot(BeNil())
+					Expect(req.Header["X-Db-Profile"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
 					fmt.Fprint(res, `} this is not valid json {`)
@@ -1857,7 +1857,7 @@ var _ = Describe(`Db2saasV1`, func() {
 
 				// Construct an instance of the PutDb2SaasAutoscaleOptions model
 				putDb2SaasAutoscaleOptionsModel := new(db2saasv1.PutDb2SaasAutoscaleOptions)
-				putDb2SaasAutoscaleOptionsModel.XDeploymentID = core.StringPtr("testString")
+				putDb2SaasAutoscaleOptionsModel.XDbProfile = core.StringPtr("testString")
 				putDb2SaasAutoscaleOptionsModel.AutoScalingEnabled = core.StringPtr("true")
 				putDb2SaasAutoscaleOptionsModel.AutoScalingThreshold = core.Int64Ptr(int64(90))
 				putDb2SaasAutoscaleOptionsModel.AutoScalingOverTimePeriod = core.Float64Ptr(float64(5))
@@ -1909,8 +1909,8 @@ var _ = Describe(`Db2saasV1`, func() {
 					}
 					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
 
-					Expect(req.Header["X-Deployment-Id"]).ToNot(BeNil())
-					Expect(req.Header["X-Deployment-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					Expect(req.Header["X-Db-Profile"]).ToNot(BeNil())
+					Expect(req.Header["X-Db-Profile"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Sleep a short time to support a timeout test
 					time.Sleep(100 * time.Millisecond)
 
@@ -1931,7 +1931,7 @@ var _ = Describe(`Db2saasV1`, func() {
 
 				// Construct an instance of the PutDb2SaasAutoscaleOptions model
 				putDb2SaasAutoscaleOptionsModel := new(db2saasv1.PutDb2SaasAutoscaleOptions)
-				putDb2SaasAutoscaleOptionsModel.XDeploymentID = core.StringPtr("testString")
+				putDb2SaasAutoscaleOptionsModel.XDbProfile = core.StringPtr("testString")
 				putDb2SaasAutoscaleOptionsModel.AutoScalingEnabled = core.StringPtr("true")
 				putDb2SaasAutoscaleOptionsModel.AutoScalingThreshold = core.Int64Ptr(int64(90))
 				putDb2SaasAutoscaleOptionsModel.AutoScalingOverTimePeriod = core.Float64Ptr(float64(5))
@@ -1989,8 +1989,8 @@ var _ = Describe(`Db2saasV1`, func() {
 					}
 					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
 
-					Expect(req.Header["X-Deployment-Id"]).ToNot(BeNil())
-					Expect(req.Header["X-Deployment-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					Expect(req.Header["X-Db-Profile"]).ToNot(BeNil())
+					Expect(req.Header["X-Db-Profile"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
@@ -2013,7 +2013,7 @@ var _ = Describe(`Db2saasV1`, func() {
 
 				// Construct an instance of the PutDb2SaasAutoscaleOptions model
 				putDb2SaasAutoscaleOptionsModel := new(db2saasv1.PutDb2SaasAutoscaleOptions)
-				putDb2SaasAutoscaleOptionsModel.XDeploymentID = core.StringPtr("testString")
+				putDb2SaasAutoscaleOptionsModel.XDbProfile = core.StringPtr("testString")
 				putDb2SaasAutoscaleOptionsModel.AutoScalingEnabled = core.StringPtr("true")
 				putDb2SaasAutoscaleOptionsModel.AutoScalingThreshold = core.Int64Ptr(int64(90))
 				putDb2SaasAutoscaleOptionsModel.AutoScalingOverTimePeriod = core.Float64Ptr(float64(5))
@@ -2038,7 +2038,7 @@ var _ = Describe(`Db2saasV1`, func() {
 
 				// Construct an instance of the PutDb2SaasAutoscaleOptions model
 				putDb2SaasAutoscaleOptionsModel := new(db2saasv1.PutDb2SaasAutoscaleOptions)
-				putDb2SaasAutoscaleOptionsModel.XDeploymentID = core.StringPtr("testString")
+				putDb2SaasAutoscaleOptionsModel.XDbProfile = core.StringPtr("testString")
 				putDb2SaasAutoscaleOptionsModel.AutoScalingEnabled = core.StringPtr("true")
 				putDb2SaasAutoscaleOptionsModel.AutoScalingThreshold = core.Int64Ptr(int64(90))
 				putDb2SaasAutoscaleOptionsModel.AutoScalingOverTimePeriod = core.Float64Ptr(float64(5))
@@ -2084,7 +2084,7 @@ var _ = Describe(`Db2saasV1`, func() {
 
 				// Construct an instance of the PutDb2SaasAutoscaleOptions model
 				putDb2SaasAutoscaleOptionsModel := new(db2saasv1.PutDb2SaasAutoscaleOptions)
-				putDb2SaasAutoscaleOptionsModel.XDeploymentID = core.StringPtr("testString")
+				putDb2SaasAutoscaleOptionsModel.XDbProfile = core.StringPtr("testString")
 				putDb2SaasAutoscaleOptionsModel.AutoScalingEnabled = core.StringPtr("true")
 				putDb2SaasAutoscaleOptionsModel.AutoScalingThreshold = core.Int64Ptr(int64(90))
 				putDb2SaasAutoscaleOptionsModel.AutoScalingOverTimePeriod = core.Float64Ptr(float64(5))
@@ -2115,8 +2115,8 @@ var _ = Describe(`Db2saasV1`, func() {
 					// Verify the contents of the request
 					Expect(req.URL.EscapedPath()).To(Equal(getDb2SaasAutoscalePath))
 					Expect(req.Method).To(Equal("GET"))
-					Expect(req.Header["X-Deployment-Id"]).ToNot(BeNil())
-					Expect(req.Header["X-Deployment-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					Expect(req.Header["X-Db-Profile"]).ToNot(BeNil())
+					Expect(req.Header["X-Db-Profile"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
 					fmt.Fprint(res, `} this is not valid json {`)
@@ -2132,7 +2132,7 @@ var _ = Describe(`Db2saasV1`, func() {
 
 				// Construct an instance of the GetDb2SaasAutoscaleOptions model
 				getDb2SaasAutoscaleOptionsModel := new(db2saasv1.GetDb2SaasAutoscaleOptions)
-				getDb2SaasAutoscaleOptionsModel.XDeploymentID = core.StringPtr("testString")
+				getDb2SaasAutoscaleOptionsModel.XDbProfile = core.StringPtr("testString")
 				getDb2SaasAutoscaleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := db2saasService.GetDb2SaasAutoscale(getDb2SaasAutoscaleOptionsModel)
@@ -2163,8 +2163,8 @@ var _ = Describe(`Db2saasV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(getDb2SaasAutoscalePath))
 					Expect(req.Method).To(Equal("GET"))
 
-					Expect(req.Header["X-Deployment-Id"]).ToNot(BeNil())
-					Expect(req.Header["X-Deployment-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					Expect(req.Header["X-Db-Profile"]).ToNot(BeNil())
+					Expect(req.Header["X-Db-Profile"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Sleep a short time to support a timeout test
 					time.Sleep(100 * time.Millisecond)
 
@@ -2185,7 +2185,7 @@ var _ = Describe(`Db2saasV1`, func() {
 
 				// Construct an instance of the GetDb2SaasAutoscaleOptions model
 				getDb2SaasAutoscaleOptionsModel := new(db2saasv1.GetDb2SaasAutoscaleOptions)
-				getDb2SaasAutoscaleOptionsModel.XDeploymentID = core.StringPtr("testString")
+				getDb2SaasAutoscaleOptionsModel.XDbProfile = core.StringPtr("testString")
 				getDb2SaasAutoscaleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -2222,8 +2222,8 @@ var _ = Describe(`Db2saasV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(getDb2SaasAutoscalePath))
 					Expect(req.Method).To(Equal("GET"))
 
-					Expect(req.Header["X-Deployment-Id"]).ToNot(BeNil())
-					Expect(req.Header["X-Deployment-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					Expect(req.Header["X-Db-Profile"]).ToNot(BeNil())
+					Expect(req.Header["X-Db-Profile"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
@@ -2246,7 +2246,7 @@ var _ = Describe(`Db2saasV1`, func() {
 
 				// Construct an instance of the GetDb2SaasAutoscaleOptions model
 				getDb2SaasAutoscaleOptionsModel := new(db2saasv1.GetDb2SaasAutoscaleOptions)
-				getDb2SaasAutoscaleOptionsModel.XDeploymentID = core.StringPtr("testString")
+				getDb2SaasAutoscaleOptionsModel.XDbProfile = core.StringPtr("testString")
 				getDb2SaasAutoscaleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -2266,7 +2266,7 @@ var _ = Describe(`Db2saasV1`, func() {
 
 				// Construct an instance of the GetDb2SaasAutoscaleOptions model
 				getDb2SaasAutoscaleOptionsModel := new(db2saasv1.GetDb2SaasAutoscaleOptions)
-				getDb2SaasAutoscaleOptionsModel.XDeploymentID = core.StringPtr("testString")
+				getDb2SaasAutoscaleOptionsModel.XDbProfile = core.StringPtr("testString")
 				getDb2SaasAutoscaleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := db2saasService.SetServiceURL("")
@@ -2307,7 +2307,7 @@ var _ = Describe(`Db2saasV1`, func() {
 
 				// Construct an instance of the GetDb2SaasAutoscaleOptions model
 				getDb2SaasAutoscaleOptionsModel := new(db2saasv1.GetDb2SaasAutoscaleOptions)
-				getDb2SaasAutoscaleOptionsModel.XDeploymentID = core.StringPtr("testString")
+				getDb2SaasAutoscaleOptionsModel.XDbProfile = core.StringPtr("testString")
 				getDb2SaasAutoscaleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -2351,12 +2351,12 @@ var _ = Describe(`Db2saasV1`, func() {
 			})
 			It(`Invoke NewGetDb2SaasAutoscaleOptions successfully`, func() {
 				// Construct an instance of the GetDb2SaasAutoscaleOptions model
-				xDeploymentID := "testString"
-				getDb2SaasAutoscaleOptionsModel := db2saasService.NewGetDb2SaasAutoscaleOptions(xDeploymentID)
-				getDb2SaasAutoscaleOptionsModel.SetXDeploymentID("testString")
+				xDbProfile := "testString"
+				getDb2SaasAutoscaleOptionsModel := db2saasService.NewGetDb2SaasAutoscaleOptions(xDbProfile)
+				getDb2SaasAutoscaleOptionsModel.SetXDbProfile("testString")
 				getDb2SaasAutoscaleOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(getDb2SaasAutoscaleOptionsModel).ToNot(BeNil())
-				Expect(getDb2SaasAutoscaleOptionsModel.XDeploymentID).To(Equal(core.StringPtr("testString")))
+				Expect(getDb2SaasAutoscaleOptionsModel.XDbProfile).To(Equal(core.StringPtr("testString")))
 				Expect(getDb2SaasAutoscaleOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewGetDb2SaasConnectionInfoOptions successfully`, func() {
@@ -2477,9 +2477,9 @@ var _ = Describe(`Db2saasV1`, func() {
 			})
 			It(`Invoke NewPutDb2SaasAutoscaleOptions successfully`, func() {
 				// Construct an instance of the PutDb2SaasAutoscaleOptions model
-				xDeploymentID := "testString"
-				putDb2SaasAutoscaleOptionsModel := db2saasService.NewPutDb2SaasAutoscaleOptions(xDeploymentID)
-				putDb2SaasAutoscaleOptionsModel.SetXDeploymentID("testString")
+				xDbProfile := "testString"
+				putDb2SaasAutoscaleOptionsModel := db2saasService.NewPutDb2SaasAutoscaleOptions(xDbProfile)
+				putDb2SaasAutoscaleOptionsModel.SetXDbProfile("testString")
 				putDb2SaasAutoscaleOptionsModel.SetAutoScalingEnabled("true")
 				putDb2SaasAutoscaleOptionsModel.SetAutoScalingThreshold(int64(90))
 				putDb2SaasAutoscaleOptionsModel.SetAutoScalingOverTimePeriod(float64(5))
@@ -2487,7 +2487,7 @@ var _ = Describe(`Db2saasV1`, func() {
 				putDb2SaasAutoscaleOptionsModel.SetAutoScalingAllowPlanLimit("YES")
 				putDb2SaasAutoscaleOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(putDb2SaasAutoscaleOptionsModel).ToNot(BeNil())
-				Expect(putDb2SaasAutoscaleOptionsModel.XDeploymentID).To(Equal(core.StringPtr("testString")))
+				Expect(putDb2SaasAutoscaleOptionsModel.XDbProfile).To(Equal(core.StringPtr("testString")))
 				Expect(putDb2SaasAutoscaleOptionsModel.AutoScalingEnabled).To(Equal(core.StringPtr("true")))
 				Expect(putDb2SaasAutoscaleOptionsModel.AutoScalingThreshold).To(Equal(core.Int64Ptr(int64(90))))
 				Expect(putDb2SaasAutoscaleOptionsModel.AutoScalingOverTimePeriod).To(Equal(core.Float64Ptr(float64(5))))


### PR DESCRIPTION
## PR summary
This PR updates the below endpoints in SDK
GET /connectioninfo
GET and PUT /manage/scaling/auto

AND adds integration tests and examples for the same

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behaviour?  
- Response of GET /connectioninfo doesn't have new fields which are added and have 2 unneeded fields.
- Header of autoscale APIs is x-deployment-id

## What is the new behaviour?  
- Extra fields are added in response of GET /connectioninfo  - `cloud_service_offering` `vpe_service_crn` `db_vpc_endpoint_service` `private_serviceName`
Removed `host_ros` and `certificateBase64`
- Header of autoscale APIs is x-db-profile

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->